### PR TITLE
feat: Require trailing comma for multiline array literals

### DIFF
--- a/internal/visitor/array_literal.go
+++ b/internal/visitor/array_literal.go
@@ -17,6 +17,19 @@ func (v *ManuscriptAstVisitor) VisitArrayLiteral(ctx *parser.ArrayLiteralContext
 				elts = append(elts, &ast.BadExpr{})
 			}
 		}
+
+		// Check for trailing comma in multiline array literals
+		startLine := ctx.GetStart().GetLine()
+		stopLine := ctx.GetStop().GetLine()
+		if stopLine > startLine {
+			if len(exprList.AllExpr()) > 0 {
+				numExprs := len(exprList.AllExpr())
+				numCommas := len(exprList.AllCOMMA())
+				if numCommas < numExprs {
+					v.addError("Multiline array literals must have a trailing comma.", ctx.GetStart())
+				}
+			}
+		}
 	}
 	return &ast.CompositeLit{
 		Type: &ast.ArrayType{Elt: ast.NewIdent("interface{}")},

--- a/tests/compilation/array_trailing_comma.md
+++ b/tests/compilation/array_trailing_comma.md
@@ -1,0 +1,65 @@
+# Test cases for array trailing commas
+
+## Multiline array without trailing comma (should error)
+
+```manuscript
+let a = [
+  1,
+  2,
+  3
+]; // Expect error: Multiline array literals must have a trailing comma.
+```
+
+## Multiline array with trailing comma (should pass)
+
+```manuscript
+let b = [
+  1,
+  2,
+  3,
+];
+```
+
+## Single-line array without trailing comma (should pass)
+
+```manuscript
+let c = [1, 2, 3];
+```
+
+## Single-line array with trailing comma (should pass)
+
+```manuscript
+let d = [1, 2, 3,];
+```
+
+## Empty array (should pass)
+
+```manuscript
+let e = [];
+```
+
+## Single element array with trailing comma (should pass)
+
+```manuscript
+let f = [1,];
+```
+
+## Single element array without trailing comma (should pass)
+
+```manuscript
+let g = [1];
+```
+
+## Multiline array with one element, no trailing comma (should error)
+```manuscript
+let h = [
+  1
+]; // Expect error: Multiline array literals must have a trailing comma.
+```
+
+## Multiline array with one element, with trailing comma (should pass)
+```manuscript
+let i = [
+  1,
+];
+```


### PR DESCRIPTION
This change introduces a new validation rule for array literals in the Manuscript language. If an array literal spans multiple lines, it must now end with a trailing comma. Single-line array literals can still have an optional trailing comma.

The `VisitArrayLiteral` method in the AST visitor has been updated to:
- Detect if an array literal is multiline by comparing start and end line numbers.
- For multiline arrays, check if a trailing comma is present by comparing the number of expressions against the number of comma tokens in the `ExprListContext`.
- Report an error using `v.addError()` if a multiline array lacks a trailing comma.

New test cases have been added to `tests/compilation/array_trailing_comma.md` to cover:
- Multiline arrays with and without trailing commas.
- Single-line arrays with and without trailing commas.
- Empty arrays.
- Single-element arrays (both single and multiline) with and without trailing commas.

All tests pass, confirming the correct behavior of the new rule.