### PR TITLE
feat: Add Hugo scaffolding for documentation website

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,11 @@ build-vscode-extension: build-lsp
 
 build-all: build-msc build-lsp build-vscode-extension
 
+build-docs:
+	@echo "Building Manuscript documentation website..."
+	hugo -s tools/docs-web -d ../../build/docs-website
+	@echo "Website built in build/docs-website"
+
 
 DIR = tests/minimal
 minimal-generate-parser:

--- a/tools/docs-web/archetypes/default.md
+++ b/tools/docs-web/archetypes/default.md
@@ -1,0 +1,5 @@
++++
+title = '{{ replace .File.ContentBaseName "-" " " | title }}'
+date = {{ .Date }}
+draft = true
++++

--- a/tools/docs-web/content/community/_index.md
+++ b/tools/docs-web/content/community/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Community"
+---

--- a/tools/docs-web/content/docs/_index.md
+++ b/tools/docs-web/content/docs/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Documentation"
+---

--- a/tools/docs-web/content/downloads/_index.md
+++ b/tools/docs-web/content/downloads/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Downloads"
+---

--- a/tools/docs-web/hugo.toml
+++ b/tools/docs-web/hugo.toml
@@ -1,0 +1,4 @@
+baseURL = 'https://example.org/'
+languageCode = 'en-us'
+title = 'Manuscript Language Docs'
+theme = "ananke" # Using a placeholder theme for initial setup.


### PR DESCRIPTION
Sets up the basic structure for a Hugo-based documentation website under tools/docs-web.

Key changes:
- Initializes a new Hugo site in tools/docs-web.
- Creates initial content sections for "docs", "downloads", and "community".
- Configures a placeholder title and theme (ananke) in hugo.toml.
- Adds a 'build-docs' target to the Makefile to build the website. The output will be in the 'build/docs-website' directory.

This provides the foundation for building out the full documentation for the Manuscript programming language. No theme files are included directly; it assumes Hugo is installed globally and can fetch themes as needed.